### PR TITLE
Stabilize widget refresh scheduling for confirmation updates

### DIFF
--- a/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/WidgetBridgeModule.kt
+++ b/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/WidgetBridgeModule.kt
@@ -7,14 +7,17 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 import java.time.Instant
 
 class WidgetBridgeModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
   private val appContext: ReactApplicationContext = reactContext
+  private val refreshScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
   override fun getName(): String = "WidgetBridge"
 
@@ -129,15 +132,38 @@ class WidgetBridgeModule(reactContext: ReactApplicationContext) : ReactContextBa
   }
 
   private fun requestWidgetRefresh() {
-    val manager = GlanceAppWidgetManager(appContext)
+    val context = appContext.applicationContext
     val widget = NewsCardGlanceWidget()
-    GlobalScope.launch(Dispatchers.Main.immediate) {
-      val ids = manager.getGlanceIds(NewsCardGlanceWidget::class.java)
+    refreshScope.launch {
+      val manager = try {
+        GlanceAppWidgetManager(context)
+      } catch (error: Exception) {
+        Log.e(TAG, "Unable to create Glance manager", error)
+        return@launch
+      }
+
+      val ids = try {
+        manager.getGlanceIds(NewsCardGlanceWidget::class.java)
+      } catch (error: Exception) {
+        Log.e(TAG, "Failed to load widget ids", error)
+        return@launch
+      }
+
       if (ids.isEmpty()) return@launch
+
       ids.forEach { glanceId ->
-        widget.update(appContext, glanceId)
+        try {
+          widget.update(context, glanceId)
+        } catch (error: Exception) {
+          Log.e(TAG, "Failed to refresh widget id=$glanceId", error)
+        }
       }
     }
+  }
+
+  override fun onCatalystInstanceDestroy() {
+    super.onCatalystInstanceDestroy()
+    refreshScope.cancel()
   }
 
   companion object {


### PR DESCRIPTION
## Summary
- replace ad-hoc coroutine launches with a dedicated scope that uses Dispatchers.Default for widget refreshes
- add defensive error handling around Glance manager creation and widget updates so refresh attempts no longer bail silently
- dispose of the refresh scope when the React bridge is destroyed to avoid leaking work

## Testing
- app:compileDebugKotlin *(fails: Gradle toolchain auto-provision still blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d37b1b262483238571a9f9bd415712