### PR TITLE
Centralize widget refresh dispatcher handling

### DIFF
--- a/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/NewsCardGlanceWidget.kt
+++ b/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/NewsCardGlanceWidget.kt
@@ -15,7 +15,6 @@ import androidx.glance.action.ActionParameters
 import androidx.glance.action.actionParametersOf
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.action.ActionCallback
@@ -761,14 +760,7 @@ class ConfirmDoseAction : ActionCallback {
     }
 
     val appContext = context.applicationContext
-    val widget = NewsCardGlanceWidget()
-    val manager = GlanceAppWidgetManager(appContext)
-    val ids = manager.getGlanceIds(NewsCardGlanceWidget::class.java)
-    if (ids.isEmpty()) {
-      widget.update(appContext, glanceId)
-    } else {
-      ids.forEach { widget.update(appContext, it) }
-    }
+    WidgetRefresher.refresh(appContext)
   }
 
   companion object {

--- a/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/WidgetBridgeModule.kt
+++ b/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/WidgetBridgeModule.kt
@@ -1,20 +1,22 @@
 package com.anonymous.HI_Vision_Mobile_App
 
 import android.util.Log
-import androidx.glance.appwidget.GlanceAppWidgetManager
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 import java.time.Instant
 
 class WidgetBridgeModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
   private val appContext: ReactApplicationContext = reactContext
+  private val refreshScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
   override fun getName(): String = "WidgetBridge"
 
@@ -129,15 +131,15 @@ class WidgetBridgeModule(reactContext: ReactApplicationContext) : ReactContextBa
   }
 
   private fun requestWidgetRefresh() {
-    val manager = GlanceAppWidgetManager(appContext)
-    val widget = NewsCardGlanceWidget()
-    GlobalScope.launch(Dispatchers.Main.immediate) {
-      val ids = manager.getGlanceIds(NewsCardGlanceWidget::class.java)
-      if (ids.isEmpty()) return@launch
-      ids.forEach { glanceId ->
-        widget.update(appContext, glanceId)
-      }
+    val context = appContext.applicationContext
+    refreshScope.launch {
+      WidgetRefresher.refresh(context)
     }
+  }
+
+  override fun onCatalystInstanceDestroy() {
+    super.onCatalystInstanceDestroy()
+    refreshScope.cancel()
   }
 
   companion object {

--- a/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/WidgetRefreshScheduler.kt
+++ b/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/WidgetRefreshScheduler.kt
@@ -1,7 +1,6 @@
 package com.anonymous.HI_Vision_Mobile_App
 
 import android.content.Context
-import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
@@ -18,10 +17,7 @@ class MedicationWidgetRefreshWorker(
   params: WorkerParameters
 ) : CoroutineWorker(appContext, params) {
   override suspend fun doWork(): Result {
-    val manager = GlanceAppWidgetManager(applicationContext)
-    val widget = NewsCardGlanceWidget()
-    val ids = manager.getGlanceIds(NewsCardGlanceWidget::class.java)
-    ids.forEach { glanceId -> widget.update(applicationContext, glanceId) }
+    WidgetRefresher.refresh(applicationContext)
     return Result.success()
   }
 }

--- a/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/WidgetRefresher.kt
+++ b/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/WidgetRefresher.kt
@@ -1,0 +1,63 @@
+package com.anonymous.HI_Vision_Mobile_App
+
+import android.content.Context
+import android.util.Log
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainCoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+object WidgetRefresher {
+  private const val TAG = "WidgetRefresher"
+
+  suspend fun refresh(context: Context) {
+    val appContext = context.applicationContext
+    val dispatcher = resolveDispatcher()
+
+    withContext(dispatcher) {
+      val widget = NewsCardGlanceWidget()
+
+      val manager = try {
+        GlanceAppWidgetManager(appContext)
+      } catch (error: Exception) {
+        if (error is CancellationException) throw error
+        Log.e(TAG, "Unable to create Glance manager", error)
+        return@withContext
+      }
+
+      val ids = try {
+        manager.getGlanceIds(NewsCardGlanceWidget::class.java)
+      } catch (error: Exception) {
+        if (error is CancellationException) throw error
+        Log.e(TAG, "Failed to load widget ids", error)
+        return@withContext
+      }
+
+      if (ids.isEmpty()) return@withContext
+
+      ids.forEach { glanceId ->
+        try {
+          widget.update(appContext, glanceId)
+        } catch (error: Exception) {
+          if (error is CancellationException) throw error
+          Log.e(TAG, "Failed to refresh widget id=$glanceId", error)
+        }
+      }
+    }
+  }
+
+  private fun resolveDispatcher(): CoroutineDispatcher {
+    val main = runCatching { Dispatchers.Main }.getOrElse { error ->
+      Log.w(TAG, "Dispatchers.Main unavailable; falling back to Dispatchers.Default", error)
+      return Dispatchers.Default
+    }
+
+    val immediate = runCatching {
+      (main as? MainCoroutineDispatcher)?.immediate
+    }.getOrNull()
+
+    return immediate ?: main
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared WidgetRefresher that resolves a usable dispatcher, logs failures, and refreshes every widget id safely
- update the React bridge, confirm action, and WorkManager worker to route refresh requests through the new helper

## Testing
- app:compileDebugKotlin *(fails: Gradle settings evaluation invokes `node` which exits with code 1 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d37b1b262483238571a9f9bd415712