### PR TITLE
Add missing CoroutineDispatcher import

### DIFF
--- a/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/WidgetBridgeModule.kt
+++ b/android/app/src/main/java/com/anonymous/HI_Vision_Mobile_App/WidgetBridgeModule.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob


### PR DESCRIPTION
## Summary
- add the missing CoroutineDispatcher import in WidgetBridgeModule to restore Kotlin compilation

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain *(fails: Cannot auto-provision Java 17 due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d3911b245483238ad05805884032d9